### PR TITLE
pass external command params to SceneBuilder #7

### DIFF
--- a/com.gluonhq.SceneBuilder.yml
+++ b/com.gluonhq.SceneBuilder.yml
@@ -75,5 +75,5 @@ modules:
         commands:
           - exec /app/jre/bin/java --module-path /app/lib/sdk --add-modules javafx.web,javafx.fxml,javafx.swing,javafx.media
             --add-opens=javafx.fxml/javafx.fxml=ALL-UNNAMED -cp /app/lib/SceneBuilder.jar
-            com.oracle.javafx.scenebuilder.app.SceneBuilderApp
+            com.oracle.javafx.scenebuilder.app.SceneBuilderApp $@
 


### PR DESCRIPTION
Helpful to open a specific fxml file passed as a parameter (suggested in #7)