### PR TITLE
Fix desktop-app-launchable-missing validatiion error

### DIFF
--- a/com.gluonhq.SceneBuilder.metainfo.xml
+++ b/com.gluonhq.SceneBuilder.metainfo.xml
@@ -5,6 +5,7 @@
   <metadata_license>CC0-1.0</metadata_license>
   <project_license>0BSD</project_license>
   <developer_name>Gluon HQ</developer_name>
+  <launchable type="desktop-id">com.gluonhq.SceneBuilder.desktop</launchable>
   <content_rating type="oars-1.1"/>
   
   <summary>Scene Builder is an open source tool that allows for drag and drop design of JavaFX user interfaces.</summary>


### PR DESCRIPTION
Once this gets merged, we can retry building #18.