### PR TITLE
Manually add latest 24.0.1 release info to metainfo.xml

### DIFF
--- a/com.gluonhq.SceneBuilder.metainfo.xml
+++ b/com.gluonhq.SceneBuilder.metainfo.xml
@@ -32,7 +32,9 @@
   <url type="donation">https://gluonhq.com/pricing/</url>
   
   <releases>
-    <release date="2025-07-03" version="24.0.1"/>
+    <release date="2025-07-03" version="24.0.1">
+      <url type="details">https://github.com/gluonhq/scenebuilder/releases/tag/24.0.1</url>
+    </release>
     <release date="2025-03-27" version="24.0.0">
       <url type="details">https://github.com/gluonhq/scenebuilder/releases/tag/24.0.0</url>
       <description>


### PR DESCRIPTION
There is no changelog for this release on SceneBuilder's release page on GitHub, which the Flathub Bot must've failed to pick up on for some reason as it didn't update the release information in #30, so I added it manually.