### PR TITLE
Fixed file open issue when path contains spaces

### DIFF
--- a/com.gluonhq.SceneBuilder.metainfo.xml
+++ b/com.gluonhq.SceneBuilder.metainfo.xml
@@ -17,11 +17,15 @@
   <screenshots>
     <screenshot type="default">
       <caption>Main window</caption>
-      <image>https://gluonhq.com/wp-content/uploads/2016/03/scene-builder-in-action.jpg</image>
+      <image>https://upload.wikimedia.org/wikipedia/commons/6/6f/Scene_builder.png</image>
     </screenshot>
     <screenshot>
-      <caption>Welcome window</caption>
-      <image>https://i2.wp.com/gluonhq.com/wp-content/uploads/2022/04/SB-welcome-dialog.png</image>
+      <caption>Main window - blank</caption>
+      <image>https://raw.githubusercontent.com/gluonhq/scenebuilder/refs/heads/master/docs/images/librarymanager/SceneBuilder01.png</image>
+    </screenshot>
+    <screenshot>
+      <caption>Library Manager - importing custom controls from ControlsFX</caption>
+      <image>https://raw.githubusercontent.com/gluonhq/scenebuilder/refs/heads/master/docs/images/librarymanager/SceneBuilder09.png</image>
     </screenshot>
   </screenshots>
 

--- a/com.gluonhq.SceneBuilder.yml
+++ b/com.gluonhq.SceneBuilder.yml
@@ -75,4 +75,4 @@ modules:
         commands:
           - exec /app/jre/bin/java --module-path /app/lib/sdk --add-modules javafx.web,javafx.fxml,javafx.swing,javafx.media
             --add-opens=javafx.fxml/javafx.fxml=ALL-UNNAMED -cp /app/lib/SceneBuilder.jar
-            com.oracle.javafx.scenebuilder.app.SceneBuilderApp $@
+            com.oracle.javafx.scenebuilder.app.SceneBuilderApp "$@"


### PR DESCRIPTION
Fixes word splitting on paths with spaces when launching Scene Builder. 

In the `SceneBuilder-runner` script, `$@` was unquoted, causing Bash to split paths containing spaces (e.g. `/home/user/My Project/ui.fxml`) into separate arguments. Adding double quotes (`"$@"`) preserves spaces as single arguments.

Should fix #38 